### PR TITLE
fix: change to use labels instead of annotations for project label

### DIFF
--- a/controllers/get_project_in_namespace.go
+++ b/controllers/get_project_in_namespace.go
@@ -25,7 +25,7 @@ func (r *SecretsReconciler) GetProjectFromObjectNamespace(ctx context.Context, c
 		return nil, fmt.Errorf("failed to retrieve namespace for object: %w", err)
 	}
 
-	v, ok := ns.Annotations[v1alpha1.ProjectKey]
+	v, ok := ns.Labels[v1alpha1.ProjectKey]
 	if !ok {
 		return nil, errNotProjectNamespace
 	}

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -290,12 +290,12 @@ func (r *ProjectReconciler) reconcileNamespace(ctx context.Context, obj *mpasv1a
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, ns, func() error {
-		if _, ok := ns.Annotations[mpasv1alpha1.ProjectKey]; !ok {
-			if ns.Annotations == nil {
-				ns.Annotations = make(map[string]string)
+		if _, ok := ns.Labels[mpasv1alpha1.ProjectKey]; !ok {
+			if ns.Labels == nil {
+				ns.Labels = make(map[string]string)
 			}
 
-			ns.Annotations[mpasv1alpha1.ProjectKey] = obj.Name
+			ns.Labels[mpasv1alpha1.ProjectKey] = obj.Name
 		}
 
 		return nil

--- a/controllers/project_controller_test.go
+++ b/controllers/project_controller_test.go
@@ -142,6 +142,6 @@ func TestProjectNamespaceAnnotation(t *testing.T) {
 	err = client.Get(context.Background(), types.NamespacedName{Name: name}, ns)
 	require.NoError(t, err)
 
-	_, ok := ns.Annotations[mpasv1alpha1.ProjectKey]
+	_, ok := ns.Labels[mpasv1alpha1.ProjectKey]
 	assert.True(t, ok)
 }

--- a/controllers/secrets_controller_test.go
+++ b/controllers/secrets_controller_test.go
@@ -26,7 +26,7 @@ func TestSecretsReconciler_Reconcile(t *testing.T) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-namespace",
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				v1alpha1.ProjectKey: "test-project",
 			},
 		},

--- a/docs/release_notes/v0.5.0.md
+++ b/docs/release_notes/v0.5.0.md
@@ -1,0 +1,6 @@
+# Release 0.5.0
+
+- fix: change to use labels instead of annotations for project label #51
+- add mend scans (#50)
+- Update action versions (#49)
+

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -5,7 +5,7 @@
 package version
 
 // ReleaseVersion is the version number in semver format "vX.Y.Z", prefixed with "v".
-var ReleaseVersion = "v0.4.0"
+var ReleaseVersion = "v0.5.0"
 
 // ReleaseCandidate is the release candidate ID in format "rc.X", which will be appended to the release version.
 var ReleaseCandidate = "rc.1"


### PR DESCRIPTION
## Description

External secrets uses label matching instead of annotations. So it couldn't find new namespaces.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
